### PR TITLE
Cocoa HttpRequestTask improvements

### DIFF
--- a/oxygine/src/HttpRequestTask.cpp
+++ b/oxygine/src/HttpRequestTask.cpp
@@ -12,7 +12,7 @@ namespace oxygine
     void HttpRequestTask::init() {}
     void HttpRequestTask::release() {}
 #endif
-    HttpRequestTask::HttpRequestTask() : _loaded(0)
+    HttpRequestTask::HttpRequestTask() : _loaded(0), _cacheEnabled(true)
     {
 
     }
@@ -39,6 +39,11 @@ namespace oxygine
         _setFileName(name);
     }
 
+	void HttpRequestTask::setCacheEnabled(bool enabled)
+	{
+		_cacheEnabled = enabled;
+		_setCacheEnabled(enabled);
+	}
 
     const std::vector<unsigned char>&   HttpRequestTask::getPostData() const
     {

--- a/oxygine/src/HttpRequestTask.h
+++ b/oxygine/src/HttpRequestTask.h
@@ -40,6 +40,7 @@ namespace oxygine
         const std::vector<unsigned char>&   getResponse() const;
         const std::vector<unsigned char>&   getPostData() const;
         const std::string&                  getFileName() const;
+		bool                                getCacheEnabled() const;
 
         /**swap version of getResponse if you want to modify result buffer inplace*/
         void getResponseSwap(std::vector<unsigned char>&);
@@ -47,6 +48,7 @@ namespace oxygine
         void setPostData(const std::vector<unsigned char>& data);
         void setUrl(const std::string& url);
         void setFileName(const std::string& name);
+		void setCacheEnabled(bool enabled);
 
 
     protected:
@@ -62,10 +64,12 @@ namespace oxygine
         virtual void _setFileName(const std::string& name) {}
         virtual void _setUrl(const std::string& url) {}
         virtual void _setPostData(const std::vector<unsigned char>& data) {}
+		virtual void _setCacheEnabled(bool enabled) {}
 
         int _loaded;
         std::string _url;
         std::string _fname;
+		bool _cacheEnabled;
         std::vector<unsigned char> _response;
         std::vector<unsigned char> _postData;
 

--- a/oxygine/src/core/ios/HttpRequestCocoaTask.h
+++ b/oxygine/src/core/ios/HttpRequestCocoaTask.h
@@ -16,7 +16,7 @@ namespace oxygine
         HttpRequestCocoaTask();
         ~HttpRequestCocoaTask();
 
-        void complete_(NSData*);
+		void complete_(NSData *data, bool error);
         void progress_(int loaded, int total);
 
     protected:


### PR DESCRIPTION
1) Support disabling cache in HttpRequestTask (Cocoa only)
2) Report errors when downloading files on iOS
3) Allow calling HttpRequestTask::init multiple times (this was being done in Demo proj and overwritten session object)
4) Some refactoring (checking if cast is valid etc)
