### PR TITLE
fix clipping on rotated objects when culling is enabled

### DIFF
--- a/oxygine/src/Actor.cpp
+++ b/oxygine/src/Actor.cpp
@@ -1502,9 +1502,15 @@ namespace oxygine
         tl = tr.transform(tl);
         br = tr.transform(br);
 
-        Vector2 size = br - tl;
+        Vector2 size = Vector2(
+			abs(br.x - tl.x),
+			abs(br.y - tl.y));
 
-        return RectF(tl, size);
+        Vector2 ntl;
+		ntl.x = std::min(tl.x, br.x);
+		ntl.y = std::min(tl.y, br.y);
+
+        return RectF(ntl, size);
     }
 
 


### PR DESCRIPTION
also fixes culling objects which disapear when overlapping the the far right
thx @ JanWosnitza

To reproduce: 
create hello world sample, in MainActor.cpp@32:
button->setCull(true);
button->setRotationDegrees(90);
run the sample and the button should not be visible due to a negative width returned. 
move the button to the far right and it will be clipped as soon as it reaches over the edge although most is still on screen. 

Without patch the button would be clipped / culled
![image](https://cloud.githubusercontent.com/assets/524935/25554023/63f0786e-2cc3-11e7-8370-0d11c01c879f.png)

