### PR TITLE
Replaced POSIX threads under Windows with stdlib implementations since it is under LGPL license

### DIFF
--- a/oxygine/src/ThreadLoader.h
+++ b/oxygine/src/ThreadLoader.h
@@ -1,7 +1,13 @@
 #pragma once
 #include "oxygine-include.h"
 #include "EventDispatcher.h"
-#include "pthread.h"
+
+#if OX_CPP11THREADS
+    #include <thread>
+#else
+    #include "pthread.h"
+#endif
+
 #include "core/ThreadDispatcher.h"
 #include <functional>
 #include "Event.h"
@@ -44,7 +50,12 @@ namespace oxygine
         void loaded(Event*);
         void _load();
 
+#if OX_CPP11THREADS
+        std::thread _thread;
+#else
         pthread_t _thread;
+#endif
+
         volatile bool _threadDone;
 
         typedef std::list<Resources*> resources;

--- a/oxygine/src/core/Mutex.cpp
+++ b/oxygine/src/core/Mutex.cpp
@@ -1,38 +1,79 @@
 #include "Mutex.h"
 #include "ox_debug.h"
-#include "pthread.h"
 
+#if OX_CPP11THREADS
+    #include <mutex>
+#else
+    #include "pthread.h"
+#endif
 
 namespace oxygine
 {
-    Mutex::Mutex(bool recursive)
+    Mutex::Mutex()
     {
-        if (recursive)
-        {
-            pthread_mutexattr_t   mta;
-            pthread_mutexattr_init(&mta);
-            pthread_mutexattr_settype(&mta, PTHREAD_MUTEX_RECURSIVE);
-
-            pthread_mutex_init(&_handle, &mta);
-        }
-        else
-        {
-            pthread_mutex_init(&_handle, 0);
-        }
+#if !OX_CPP11THREADS
+        pthread_mutex_init(&_handle, 0);
+#endif
     }
 
     Mutex::~Mutex()
     {
+#if !OX_CPP11THREADS
         pthread_mutex_destroy(&_handle);
+#endif
     }
 
     void Mutex::lock()
     {
+#if OX_CPP11THREADS
+        _mutex.lock();
+#else
         pthread_mutex_lock(&_handle);
+#endif
     }
 
     void Mutex::unlock()
     {
+#if OX_CPP11THREADS
+        _mutex.unlock();
+#else
         pthread_mutex_unlock(&_handle);
+#endif
+    }
+
+    MutexRecursive::MutexRecursive()
+    {
+#if !OX_CPP11THREADS
+        pthread_mutexattr_t   mta;
+        pthread_mutexattr_init(&mta);
+        pthread_mutexattr_settype(&mta, PTHREAD_MUTEX_RECURSIVE);
+
+        pthread_mutex_init(&_handle, &mta);
+#endif
+    }
+
+    MutexRecursive::~MutexRecursive()
+    {
+#if !OX_CPP11THREADS
+        pthread_mutex_destroy(&_handle);
+#endif
+    }
+
+    void MutexRecursive::lock()
+    {
+#if OX_CPP11THREADS
+        _mutex.lock();
+#else
+        pthread_mutex_lock(&_handle);
+#endif
+    }
+
+    void MutexRecursive::unlock()
+    {
+#if OX_CPP11THREADS
+        _mutex.unlock();
+#else
+        pthread_mutex_unlock(&_handle);
+#endif
     }
 }

--- a/oxygine/src/core/Mutex.h
+++ b/oxygine/src/core/Mutex.h
@@ -1,10 +1,16 @@
 #pragma once
 #include "oxygine-include.h"
 
+#if OX_CPP11THREADS
+    #include <mutex>
+#else
+
 #if defined(_WIN32) && !defined(__MINGW32__)
 typedef struct pthread_mutex_t_* pthread_mutex_t;
 #else
 #   include "pthread.h"
+#endif
+
 #endif
 
 namespace oxygine
@@ -12,7 +18,7 @@ namespace oxygine
     class Mutex
     {
     public:
-        Mutex(bool recursive = false);
+        Mutex();
         ~Mutex();
 
         void lock();
@@ -22,8 +28,33 @@ namespace oxygine
         Mutex(const Mutex&) {}
         void operator = (const Mutex&) {}
 
+#if OX_CPP11THREADS
+        std::mutex _mutex;
+#else
         pthread_mutex_t _handle;
         //void *_handle;
+#endif
+    };
+
+    class MutexRecursive
+    {
+    public:
+        MutexRecursive();
+        ~MutexRecursive();
+
+        void lock();
+        void unlock();
+
+    private:
+        MutexRecursive(const MutexRecursive&) {}
+        void operator = (const MutexRecursive&) {}
+
+#if OX_CPP11THREADS
+        std::recursive_mutex _mutex;
+#else
+        pthread_mutex_t _handle;
+        //void *_handle;
+#endif
     };
 
     class MutexAutoLock
@@ -34,5 +65,15 @@ namespace oxygine
 
     private:
         Mutex& _m;
+    };
+
+    class MutexRecursiveAutoLock
+    {
+    public:
+        MutexRecursiveAutoLock(MutexRecursive& m): _m(m) {_m.lock();}
+        ~MutexRecursiveAutoLock() {_m.unlock();}
+
+    private:
+        MutexRecursive& _m;
     };
 }

--- a/oxygine/src/core/ZipFileSystem.cpp
+++ b/oxygine/src/core/ZipFileSystem.cpp
@@ -40,7 +40,7 @@ namespace oxygine
             return true;
         }
 
-        Zips::Zips(): _sort(false), _lock(true)
+        Zips::Zips(): _sort(false)
         {
 
         }
@@ -74,7 +74,7 @@ namespace oxygine
 
         void Zips::add(const unsigned char* data, unsigned int size)
         {
-            MutexAutoLock al(_lock);
+            MutexRecursiveAutoLock al(_lock);
 
             zlib_filefunc_def ff;
             fill_memory_filefunc(&ff);
@@ -98,7 +98,7 @@ namespace oxygine
 
         void Zips::add(std::vector<char>& data)
         {
-            MutexAutoLock al(_lock);
+            MutexRecursiveAutoLock al(_lock);
 
             zlib_filefunc_def ff;
             fill_memory_filefunc(&ff);
@@ -163,7 +163,7 @@ namespace oxygine
 
         void Zips::add(const char* name)
         {
-            MutexAutoLock al(_lock);
+            MutexRecursiveAutoLock al(_lock);
 
             zlib_filefunc_def zpfs;
             memset(&zpfs, 0, sizeof(zpfs));
@@ -205,13 +205,13 @@ namespace oxygine
 
         bool Zips::isExists(const char* name)
         {
-            MutexAutoLock al(_lock);
+            MutexRecursiveAutoLock al(_lock);
             return getEntryByName(name) != 0;
         }
 
         bool Zips::read(const char* name, file::buffer& bf)
         {
-            MutexAutoLock al(_lock);
+            MutexRecursiveAutoLock al(_lock);
 
             const file_entry* entry = getEntryByName(name);
             if (!entry)
@@ -221,13 +221,13 @@ namespace oxygine
 
         bool Zips::read(const file_entry* entry, file::buffer& bf)
         {
-            MutexAutoLock al(_lock);
+            MutexRecursiveAutoLock al(_lock);
             return readEntry(entry, bf);
         }
 
         void Zips::reset()
         {
-            MutexAutoLock al(_lock);
+            MutexRecursiveAutoLock al(_lock);
             for (zips::iterator i = _zps.begin(); i != _zps.end(); ++i)
             {
                 zpitem& f = *i;
@@ -456,7 +456,7 @@ namespace oxygine
 
         FileSystem::status ZipFileSystem::_open(const char* file, const char* mode, error_policy ep, file::fileHandle*& fh)
         {
-            MutexAutoLock lock(_zips._lock);
+            MutexRecursiveAutoLock lock(_zips._lock);
 
             const file_entry* entry = _zips.getEntryByName(file);
             if (entry)

--- a/oxygine/src/core/ZipFileSystem.h
+++ b/oxygine/src/core/ZipFileSystem.h
@@ -61,7 +61,7 @@ namespace oxygine
             typedef std::vector<zpitem> zips;
             zips _zps;
 
-            Mutex _lock;
+            MutexRecursive _lock;
         };
 
         bool read(file_entry* entry, file::buffer& bf);

--- a/oxygine/src/core/oxygine.cpp
+++ b/oxygine/src/core/oxygine.cpp
@@ -55,7 +55,11 @@
 #include "ios/ios.h"
 #endif
 
-#include "pthread.h"
+#if OX_CPP11THREADS
+    #include <thread>
+#else
+    #include "pthread.h"
+#endif
 
 #ifdef OXYGINE_SDL
 extern "C"
@@ -100,7 +104,11 @@ namespace oxygine
 
     spEventDispatcher _dispatcher;
 
+#if OX_CPP11THREADS
+    static std::thread::id _mainThread;
+#else
     static pthread_t _mainThread;
+#endif
 
 #ifdef __S3E__
 
@@ -222,7 +230,11 @@ namespace oxygine
 #ifdef OX_NO_MT
             return true;
 #else
+    #if OX_CPP11THREADS
+            return _mainThread == std::this_thread::get_id();
+    #else
             return pthread_equal(_mainThread, pthread_self()) != 0;
+    #endif
 #endif
         }
 
@@ -443,7 +455,11 @@ namespace oxygine
         {
 
 #ifndef OX_NO_MT
+    #if OX_CPP11THREADS
+            _mainThread = std::this_thread::get_id();
+    #else
             _mainThread = pthread_self();
+    #endif
 #endif
 
             if (!_dispatcher)

--- a/oxygine/src/res/CreateResourceContext.cpp
+++ b/oxygine/src/res/CreateResourceContext.cpp
@@ -3,7 +3,10 @@
 #include "Image.h"
 #include "core/ThreadDispatcher.h"
 #include "core/oxygine.h"
-#include "pthread.h"
+
+#if !OX_CPP11THREADS
+    #include "pthread.h"
+#endif
 
 namespace oxygine
 {


### PR DESCRIPTION
The oxygine engine uses POSIX threads under Windows which is a handy library but sadly under LGPL so we cannot link it statically. Since C++ 11 there are official implementations std::mutex, std::thread and std::conditional_variable. So I put those in which gets rid of POSIX threads under Windows which resolves our licensing issue. There is a define OX_CPP11THREADS that needs to be set in order to enable the use of the stdlib classes.