### PR TITLE
Extended window flags

### DIFF
--- a/oxygine/src/core/oxygine.cpp
+++ b/oxygine/src/core/oxygine.cpp
@@ -324,7 +324,7 @@ namespace oxygine
             log::messageln("SDL build");
 
 
-            SDL_SetHint(SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "1");
+            SDL_SetHint(SDL_HINT_VIDEO_ALLOW_SCREENSAVER, desc.allow_screensaver ? "1" : "0");
 
             SDL_Init(SDL_INIT_VIDEO);
 
@@ -358,11 +358,21 @@ namespace oxygine
 
             SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
 
-            int flags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN;
+            int flags = SDL_WINDOW_OPENGL;
 
 #if TARGET_OS_IPHONE
+            flags |= SDL_WINDOW_SHOWN;
             flags |= SDL_WINDOW_BORDERLESS;
             flags |= SDL_WINDOW_ALLOW_HIGHDPI;
+#else
+            if(desc.show_window)
+                flags |= SDL_WINDOW_SHOWN;
+
+            if(desc.borderless)
+                flags |= SDL_WINDOW_BORDERLESS;
+
+            if(desc.resizable)
+                flags |= SDL_WINDOW_RESIZABLE;
 #endif
 
             //SDL_DisplayMode mode;

--- a/oxygine/src/core/oxygine.h
+++ b/oxygine/src/core/oxygine.h
@@ -43,18 +43,30 @@ namespace oxygine
     {
         struct init_desc
         {
-            init_desc() : mode24bpp(true), w(-1), h(-1), fullscreen(false), title("Oxygine"), vsync(true), appName(0), companyName(0), force_gles(false) {}
+            init_desc() :w(-1), h(-1),  mode24bpp(true), vsync(true), fullscreen(false), resizable(false), borderless(false), show_window(true), force_gles(false), allow_screensaver(true), title("Oxygine"), appName(0), companyName(0) {}
 
-            /**sets 24 bits per pixel, otherwise sets 16 bits per pixel?*/
-            bool mode24bpp;
             /**display width*/
             int w;
             /**display height*/
             int h;
+
+            /**sets 24 bits per pixel, otherwise sets 16 bits per pixel?*/
+            unsigned int mode24bpp :1;
             /**vertical sync*/
-            bool vsync;
+            unsigned int vsync :1;
             /**fullscreen mode*/
-            bool fullscreen;
+            unsigned int fullscreen :1;
+            /**can the window be resized*/
+            unsigned int resizable :1;
+            /**borderless window*/
+            unsigned int borderless :1;
+            /**will the window be visible*/
+            unsigned int show_window :1;
+            /**use OpenGLES driver. Could be used on Windows for emulation OpenGLES via Direct3D*/
+            unsigned int force_gles :1;
+            /**allow screensaver*/
+            unsigned int allow_screensaver :1;
+
             /**window title*/
             const char* title;
 
@@ -62,9 +74,6 @@ namespace oxygine
             const char* appName;
             /** Company name to be used as part of the file system directory for writable storage*/
             const char* companyName;
-
-            /**use OpenGLES driver. Could be used on Windows for emulation OpenGLES via Direct3D*/
-            bool force_gles;
         };
 
         void init0();


### PR DESCRIPTION
Extended window flags so you can create a borderless window that disallows screensavers and can be hidden at start. Packed all boolean init flags into bitmask.