### PR TITLE
Add SailfishOS support

### DIFF
--- a/examples/Demo/proj.sfos/CMakeLists.txt
+++ b/examples/Demo/proj.sfos/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required (VERSION 2.6)
+project (Demo)
+
+add_definitions( -D__SAILFISHOS__=1 )
+add_subdirectory(../../../ oxygine-framework)
+add_definitions(${OXYGINE_DEFINITIONS})
+include_directories(${OXYGINE_INCLUDE_DIRS})
+link_directories(${OXYGINE_LIBRARY_DIRS})
+
+set(CMAKE_CXX_FLAGS "-lGLESv2 ${CMAKE_CXX_FLAGS} ${OXYGINE_CXX_FLAGS}")
+
+add_executable(Demo ../src/Counter.cpp ../src/example.cpp ../src/main.cpp ../src/test.cpp  ../src/Counter.h ../src/TestAlphaHitTest.h ../src/TestBox9Sprite.h ../src/TestClipRect.h ../src/TestColorFont.h ../src/TestCounter.h ../src/TestDrag.h ../src/TestEdges.h ../src/TestHttp.h ../src/TestInputText.h ../src/TestManageRes.h ../src/TestMask.h ../src/TestPerf.h ../src/TestPolygon.h ../src/TestProgressBar.h ../src/TestRender2Texture.h ../src/TestSignedDistanceFont.h ../src/TestSliding.h ../src/TestTexel2Pixel.h ../src/TestText.h ../src/TestTextureFormat.h ../src/TestTouches.h ../src/TestTweenPostProcessing.h ../src/TestTweenShine.h ../src/TestTweenText.h ../src/TestTweens.h ../src/TestUserShader.h ../src/TestUserShader2.h ../src/example.h ../src/test.h )
+target_link_libraries(Demo ${OXYGINE_CORE_LIBS})
+
+
+
+if (WIN32) #disable console mode for VC++
+	set_target_properties(Demo PROPERTIES WIN32_EXECUTABLE TRUE)
+endif(WIN32)
+
+
+
+if (EMSCRIPTEN)
+	SET(CMAKE_EXECUTABLE_SUFFIX ".html")	
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s NO_EXIT_RUNTIME=1 -s WARN_ON_UNDEFINED_SYMBOLS=1 --memory-init-file 0 -s TOTAL_MEMORY=50331648")
+	em_link_pre_js(Demo  ${OXYGINE_JS_LIBRARIES}  ${CMAKE_CURRENT_SOURCE_DIR}/data.js)
+endif(EMSCRIPTEN)

--- a/examples/Demo/proj.sfos/build_emsc.bat
+++ b/examples/Demo/proj.sfos/build_emsc.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc
+cd build_emsc
+cmake -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/Demo/proj.sfos/build_emsc_release.bat
+++ b/examples/Demo/proj.sfos/build_emsc_release.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc_release
+cd build_emsc_release
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/Demo/proj.sfos/run.sh
+++ b/examples/Demo/proj.sfos/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+mkdir build
+cd build
+
+#generate cmake project in the "build" folder
+cmake ..
+
+#build it
+make
+
+#move to working data folder with resources
+cd ../../data
+
+#run executable
+./../proj.cmake/build/Demo

--- a/examples/DemoBox2D/proj.sfos/CMakeLists.txt
+++ b/examples/DemoBox2D/proj.sfos/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required (VERSION 2.6)
+project (DemoBox2D)
+
+add_definitions( -D__SAILFISHOS__=1 )
+add_subdirectory(../../../ oxygine-framework)
+add_definitions(${OXYGINE_DEFINITIONS})
+include_directories(${OXYGINE_INCLUDE_DIRS})
+link_directories(${OXYGINE_LIBRARY_DIRS})
+
+file(GLOB_RECURSE BOX2DSRC
+		../box2d/*.cpp
+		../box2d/*.h)
+
+set(CMAKE_CXX_FLAGS "-lGLESv2 ${CMAKE_CXX_FLAGS} ${OXYGINE_CXX_FLAGS}")
+
+add_executable(DemoBox2D ${BOX2DSRC} ../src/Box2DDebugDraw.cpp ../src/main.cpp ../src/example.cpp  ../src/Box2DDebugDraw.h ../src/example.h )
+source_group(box2d FILES ${BOX2DSRC})
+include_directories(../box2d)
+
+target_link_libraries(DemoBox2D ${OXYGINE_CORE_LIBS})
+
+
+
+
+if (WIN32) #disable console mode for VC++
+	set_target_properties(DemoBox2D PROPERTIES WIN32_EXECUTABLE TRUE)
+endif(WIN32)
+
+
+
+if (EMSCRIPTEN)
+	SET(CMAKE_EXECUTABLE_SUFFIX ".html")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s NO_EXIT_RUNTIME=1 -s WARN_ON_UNDEFINED_SYMBOLS=1 --memory-init-file 0 -s TOTAL_MEMORY=50331648")
+	em_link_pre_js(DemoBox2D  ${OXYGINE_JS_LIBRARIES}  ${CMAKE_CURRENT_SOURCE_DIR}/data.js)
+endif(EMSCRIPTEN)

--- a/examples/DemoBox2D/proj.sfos/build_emsc.bat
+++ b/examples/DemoBox2D/proj.sfos/build_emsc.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc
+cd build_emsc
+cmake -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/DemoBox2D/proj.sfos/build_emsc_release.bat
+++ b/examples/DemoBox2D/proj.sfos/build_emsc_release.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc_release
+cd build_emsc_release
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/DemoBox2D/proj.sfos/run.sh
+++ b/examples/DemoBox2D/proj.sfos/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+mkdir build
+cd build
+
+#generate cmake project in the "build" folder
+cmake ..
+
+#build it
+make
+
+#move to working data folder with resources
+cd ../../data
+
+#run executable
+./../proj.cmake/build/DemoBox2D

--- a/examples/Game/part1/proj.sfos/CMakeLists.txt
+++ b/examples/Game/part1/proj.sfos/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required (VERSION 2.6)
+project (GamePart1)
+
+add_definitions( -D__SAILFISHOS__=1 )
+add_subdirectory(../../../../ oxygine-framework)
+add_definitions(${OXYGINE_DEFINITIONS})
+include_directories(${OXYGINE_INCLUDE_DIRS})
+link_directories(${OXYGINE_LIBRARY_DIRS})
+
+set(CMAKE_CXX_FLAGS "-lGLESv2 ${CMAKE_CXX_FLAGS} ${OXYGINE_CXX_FLAGS}")
+
+add_executable(GamePart1 ../src/Game.cpp ../src/Joystick.cpp ../src/Player.cpp ../src/Unit.cpp ../src/example.cpp ../src/main.cpp ../src/res.cpp  ../src/Game.h ../src/Joystick.h ../src/Player.h ../src/Unit.h ../src/example.h ../src/res.h )
+target_link_libraries(GamePart1 ${OXYGINE_CORE_LIBS})
+
+
+
+if (WIN32) #disable console mode for VC++
+	set_target_properties(GamePart1 PROPERTIES WIN32_EXECUTABLE TRUE)
+endif(WIN32)
+
+
+
+if (EMSCRIPTEN)
+	SET(CMAKE_EXECUTABLE_SUFFIX ".html")	
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s NO_EXIT_RUNTIME=1 -s WARN_ON_UNDEFINED_SYMBOLS=1 --memory-init-file 0 -s TOTAL_MEMORY=50331648")
+	em_link_pre_js(GamePart1  ${OXYGINE_JS_LIBRARIES}  ${CMAKE_CURRENT_SOURCE_DIR}/data.js)
+endif(EMSCRIPTEN)

--- a/examples/Game/part1/proj.sfos/build_emsc.bat
+++ b/examples/Game/part1/proj.sfos/build_emsc.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc
+cd build_emsc
+cmake -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/Game/part1/proj.sfos/build_emsc_release.bat
+++ b/examples/Game/part1/proj.sfos/build_emsc_release.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc_release
+cd build_emsc_release
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/Game/part1/proj.sfos/run.sh
+++ b/examples/Game/part1/proj.sfos/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+mkdir build
+cd build
+
+#generate cmake project in the "build" folder
+cmake ..
+
+#build it
+make
+
+#move to working data folder with resources
+cd ../../data
+
+#run executable
+./../proj.cmake/build/GamePart1

--- a/examples/Game/part2/proj.sfos/CMakeLists.txt
+++ b/examples/Game/part2/proj.sfos/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required (VERSION 2.6)
+project (GamePart2)
+
+add_definitions( -D__SAILFISHOS__=1 )
+add_subdirectory(../../../../ oxygine-framework)
+add_definitions(${OXYGINE_DEFINITIONS})
+include_directories(${OXYGINE_INCLUDE_DIRS})
+link_directories(${OXYGINE_LIBRARY_DIRS})
+
+set(CMAKE_CXX_FLAGS "-lGLESv2 ${CMAKE_CXX_FLAGS} ${OXYGINE_CXX_FLAGS}")
+
+add_executable(GamePart2 ../src/Enemy.cpp ../src/Game.cpp ../src/Joystick.cpp ../src/Player.cpp ../src/Rocket.cpp ../src/Unit.cpp ../src/example.cpp ../src/main.cpp ../src/res.cpp  ../src/Enemy.h ../src/Game.h ../src/Joystick.h ../src/Player.h ../src/Rocket.h ../src/Unit.h ../src/example.h ../src/res.h )
+target_link_libraries(GamePart2 ${OXYGINE_CORE_LIBS})
+
+
+
+if (WIN32) #disable console mode for VC++
+	set_target_properties(GamePart2 PROPERTIES WIN32_EXECUTABLE TRUE)
+endif(WIN32)
+
+
+
+if (EMSCRIPTEN)
+	SET(CMAKE_EXECUTABLE_SUFFIX ".html")	
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s NO_EXIT_RUNTIME=1 -s WARN_ON_UNDEFINED_SYMBOLS=1 --memory-init-file 0 -s TOTAL_MEMORY=50331648")
+	em_link_pre_js(GamePart2  ${OXYGINE_JS_LIBRARIES}  ${CMAKE_CURRENT_SOURCE_DIR}/data.js)
+endif(EMSCRIPTEN)

--- a/examples/Game/part2/proj.sfos/build_emsc.bat
+++ b/examples/Game/part2/proj.sfos/build_emsc.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc
+cd build_emsc
+cmake -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/Game/part2/proj.sfos/build_emsc_release.bat
+++ b/examples/Game/part2/proj.sfos/build_emsc_release.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc_release
+cd build_emsc_release
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/Game/part2/proj.sfos/run.sh
+++ b/examples/Game/part2/proj.sfos/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+mkdir build
+cd build
+
+#generate cmake project in the "build" folder
+cmake ..
+
+#build it
+make
+
+#move to working data folder with resources
+cd ../../data
+
+#run executable
+./../proj.cmake/build/GamePart2

--- a/examples/Game/part3/proj.sfos/CMakeLists.txt
+++ b/examples/Game/part3/proj.sfos/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required (VERSION 2.6)
+project (GamePart3)
+
+add_definitions( -D__SAILFISHOS__=1 )
+add_subdirectory(../../../../ oxygine-framework)
+add_definitions(${OXYGINE_DEFINITIONS})
+include_directories(${OXYGINE_INCLUDE_DIRS})
+link_directories(${OXYGINE_LIBRARY_DIRS})
+
+set(CMAKE_CXX_FLAGS "-lGLESv2 ${CMAKE_CXX_FLAGS} ${OXYGINE_CXX_FLAGS}")
+
+add_executable(GamePart3 ../src/Enemy.cpp ../src/Game.cpp ../src/GameScene.cpp ../src/Joystick.cpp ../src/MainMenuScene.cpp ../src/MyButton.cpp ../src/Player.cpp ../src/Rocket.cpp ../src/Scene.cpp ../src/Unit.cpp ../src/example.cpp ../src/main.cpp ../src/res.cpp  ../src/Enemy.h ../src/Game.h ../src/GameScene.h ../src/Joystick.h ../src/MainMenuScene.h ../src/MyButton.h ../src/Player.h ../src/Rocket.h ../src/Scene.h ../src/Unit.h ../src/example.h ../src/res.h )
+target_link_libraries(GamePart3 ${OXYGINE_CORE_LIBS})
+
+
+
+if (WIN32) #disable console mode for VC++
+	set_target_properties(GamePart3 PROPERTIES WIN32_EXECUTABLE TRUE)
+endif(WIN32)
+
+
+
+if (EMSCRIPTEN)
+	SET(CMAKE_EXECUTABLE_SUFFIX ".html")	
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s NO_EXIT_RUNTIME=1 -s WARN_ON_UNDEFINED_SYMBOLS=1 --memory-init-file 0 -s TOTAL_MEMORY=50331648")
+	em_link_pre_js(GamePart3  ${OXYGINE_JS_LIBRARIES}  ${CMAKE_CURRENT_SOURCE_DIR}/data.js)
+endif(EMSCRIPTEN)

--- a/examples/Game/part3/proj.sfos/build_emsc.bat
+++ b/examples/Game/part3/proj.sfos/build_emsc.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc
+cd build_emsc
+cmake -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/Game/part3/proj.sfos/build_emsc_release.bat
+++ b/examples/Game/part3/proj.sfos/build_emsc_release.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc_release
+cd build_emsc_release
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/Game/part3/proj.sfos/run.sh
+++ b/examples/Game/part3/proj.sfos/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+mkdir build
+cd build
+
+#generate cmake project in the "build" folder
+cmake ..
+
+#build it
+make
+
+#move to working data folder with resources
+cd ../../data
+
+#run executable
+./../proj.cmake/build/GamePart3

--- a/examples/Game/part4/proj.cmake/CMakeLists.txt
+++ b/examples/Game/part4/proj.cmake/CMakeLists.txt
@@ -1,12 +1,13 @@
 cmake_minimum_required (VERSION 2.6)
 project (GamePart4)
 
+add_definitions( -D__SAILFISHOS__=1 )
 add_subdirectory(../../../../ oxygine-framework)
 add_definitions(${OXYGINE_DEFINITIONS})
 include_directories(${OXYGINE_INCLUDE_DIRS})
 link_directories(${OXYGINE_LIBRARY_DIRS})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OXYGINE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-lGLESv2 ${CMAKE_CXX_FLAGS} ${OXYGINE_CXX_FLAGS}")
 
 add_executable(GamePart4 ../src/Enemy.cpp ../src/Game.cpp ../src/GameMenu.cpp ../src/GameScene.cpp ../src/Joystick.cpp ../src/MainMenuScene.cpp ../src/MyButton.cpp ../src/Player.cpp ../src/Rocket.cpp ../src/Scene.cpp ../src/Unit.cpp ../src/example.cpp ../src/main.cpp ../src/res.cpp  ../src/Enemy.h ../src/Game.h ../src/GameMenu.h ../src/GameScene.h ../src/Joystick.h ../src/MainMenuScene.h ../src/MyButton.h ../src/Player.h ../src/Rocket.h ../src/Scene.h ../src/Unit.h ../src/example.h ../src/res.h )
 target_link_libraries(GamePart4 ${OXYGINE_CORE_LIBS})

--- a/examples/Game/part5/proj.sfos/CMakeLists.txt
+++ b/examples/Game/part5/proj.sfos/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required (VERSION 2.6)
+project (GamePart5)
+
+add_definitions( -D__SAILFISHOS__=1 )
+add_subdirectory(../../../../ oxygine-framework)
+add_definitions(${OXYGINE_DEFINITIONS})
+include_directories(${OXYGINE_INCLUDE_DIRS})
+link_directories(${OXYGINE_LIBRARY_DIRS})
+
+set(CMAKE_CXX_FLAGS "-lGLESv2 ${CMAKE_CXX_FLAGS} ${OXYGINE_CXX_FLAGS}")
+
+add_executable(GamePart5 ../src/Enemy.cpp ../src/Game.cpp ../src/GameMenu.cpp ../src/GameScene.cpp ../src/Joystick.cpp ../src/MainMenuScene.cpp ../src/MyButton.cpp ../src/Player.cpp ../src/Rocket.cpp ../src/Scene.cpp ../src/Unit.cpp ../src/example.cpp ../src/main.cpp ../src/res.cpp  ../src/Enemy.h ../src/Game.h ../src/GameMenu.h ../src/GameScene.h ../src/Joystick.h ../src/MainMenuScene.h ../src/MyButton.h ../src/Player.h ../src/Rocket.h ../src/Scene.h ../src/Unit.h ../src/example.h ../src/res.h )
+target_link_libraries(GamePart5 ${OXYGINE_CORE_LIBS})
+
+
+
+if (WIN32) #disable console mode for VC++
+	set_target_properties(GamePart5 PROPERTIES WIN32_EXECUTABLE TRUE)
+endif(WIN32)
+
+
+
+if (EMSCRIPTEN)
+	SET(CMAKE_EXECUTABLE_SUFFIX ".html")	
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s NO_EXIT_RUNTIME=1 -s WARN_ON_UNDEFINED_SYMBOLS=1 --memory-init-file 0 -s TOTAL_MEMORY=50331648")
+	em_link_pre_js(GamePart5  ${OXYGINE_JS_LIBRARIES}  ${CMAKE_CURRENT_SOURCE_DIR}/data.js)
+endif(EMSCRIPTEN)

--- a/examples/Game/part5/proj.sfos/build_emsc.bat
+++ b/examples/Game/part5/proj.sfos/build_emsc.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc
+cd build_emsc
+cmake -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/Game/part5/proj.sfos/build_emsc_release.bat
+++ b/examples/Game/part5/proj.sfos/build_emsc_release.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc_release
+cd build_emsc_release
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/Game/part5/proj.sfos/run.sh
+++ b/examples/Game/part5/proj.sfos/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+mkdir build
+cd build
+
+#generate cmake project in the "build" folder
+cmake ..
+
+#build it
+make
+
+#move to working data folder with resources
+cd ../../data
+
+#run executable
+./../proj.cmake/build/GamePart5

--- a/examples/HelloWorld/proj.sfos/CMakeLists.txt
+++ b/examples/HelloWorld/proj.sfos/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required (VERSION 2.6)
+project (HelloWorld)
+
+add_definitions( -D__SAILFISHOS__=1 )
+add_subdirectory(../../../ oxygine-framework)
+add_definitions(${OXYGINE_DEFINITIONS})
+include_directories(${OXYGINE_INCLUDE_DIRS})
+link_directories(${OXYGINE_LIBRARY_DIRS})
+
+set(CMAKE_CXX_FLAGS "-lGLESv2 ${CMAKE_CXX_FLAGS} ${OXYGINE_CXX_FLAGS}")
+
+add_executable(HelloWorld ../src/example.cpp ../src/main.cpp  ../src/example.h )
+target_link_libraries(HelloWorld ${OXYGINE_CORE_LIBS})
+
+
+
+if (WIN32) #disable console mode for VC++
+	set_target_properties(HelloWorld PROPERTIES WIN32_EXECUTABLE TRUE)
+endif(WIN32)
+
+
+
+if (EMSCRIPTEN)
+	SET(CMAKE_EXECUTABLE_SUFFIX ".html")	
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s NO_EXIT_RUNTIME=1 -s WARN_ON_UNDEFINED_SYMBOLS=1 --memory-init-file 0 -s TOTAL_MEMORY=50331648")
+	em_link_pre_js(HelloWorld  ${OXYGINE_JS_LIBRARIES}  ${CMAKE_CURRENT_SOURCE_DIR}/data.js)
+endif(EMSCRIPTEN)

--- a/examples/HelloWorld/proj.sfos/build_emsc.bat
+++ b/examples/HelloWorld/proj.sfos/build_emsc.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc
+cd build_emsc
+cmake -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/HelloWorld/proj.sfos/build_emsc_release.bat
+++ b/examples/HelloWorld/proj.sfos/build_emsc_release.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc_release
+cd build_emsc_release
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/HelloWorld/proj.sfos/run.sh
+++ b/examples/HelloWorld/proj.sfos/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+mkdir build
+cd build
+
+#generate cmake project in the "build" folder
+cmake ..
+
+#build it
+make
+
+#move to working data folder with resources
+cd ../../data
+
+#run executable
+./../proj.cmake/build/HelloWorld

--- a/examples/Match3/proj.sfos/CMakeLists.txt
+++ b/examples/Match3/proj.sfos/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required (VERSION 2.6)
+project (Match3)
+
+add_definitions( -D__SAILFISHOS__=1 )
+add_subdirectory(../../../ oxygine-framework)
+add_definitions(${OXYGINE_DEFINITIONS})
+include_directories(${OXYGINE_INCLUDE_DIRS})
+link_directories(${OXYGINE_LIBRARY_DIRS})
+
+set(CMAKE_CXX_FLAGS "-lGLESv2 ${CMAKE_CXX_FLAGS} ${OXYGINE_CXX_FLAGS}")
+
+add_executable(Match3 ../src/Board.cpp ../src/Jewel.cpp ../src/example.cpp ../src/main.cpp ../src/shared.cpp  ../src/Board.h ../src/Jewel.h ../src/example.h ../src/shared.h )
+target_link_libraries(Match3 ${OXYGINE_CORE_LIBS})
+
+
+
+if (WIN32) #disable console mode for VC++
+	set_target_properties(Match3 PROPERTIES WIN32_EXECUTABLE TRUE)
+endif(WIN32)
+
+
+
+if (EMSCRIPTEN)
+	SET(CMAKE_EXECUTABLE_SUFFIX ".html")	
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s NO_EXIT_RUNTIME=1 -s WARN_ON_UNDEFINED_SYMBOLS=1 --memory-init-file 0 -s TOTAL_MEMORY=50331648")
+	em_link_pre_js(Match3  ${OXYGINE_JS_LIBRARIES}  ${CMAKE_CURRENT_SOURCE_DIR}/data.js)
+endif(EMSCRIPTEN)

--- a/examples/Match3/proj.sfos/build_emsc.bat
+++ b/examples/Match3/proj.sfos/build_emsc.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc
+cd build_emsc
+cmake -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/Match3/proj.sfos/build_emsc_release.bat
+++ b/examples/Match3/proj.sfos/build_emsc_release.bat
@@ -1,0 +1,9 @@
+call emsdk activate
+
+python ../../..//tools/others/embed_folder_js.py -s ../data
+
+mkdir build_emsc_release
+cd build_emsc_release
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="%EMSCRIPTEN%/cmake/Modules/Platform/emscripten.cmake" -G"Unix Makefiles" ..
+make
+cd ..

--- a/examples/Match3/proj.sfos/run.sh
+++ b/examples/Match3/proj.sfos/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+mkdir build
+cd build
+
+#generate cmake project in the "build" folder
+cmake ..
+
+#build it
+make
+
+#move to working data folder with resources
+cd ../../data
+
+#run executable
+./../proj.cmake/build/HelloWorld

--- a/oxygine/src/core/gl/VideoDriverGLES20.cpp
+++ b/oxygine/src/core/gl/VideoDriverGLES20.cpp
@@ -15,7 +15,7 @@
 #endif
 
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) || defined(__SAILFISHOS__)
 #include "GLES2/gl2.h"
 #endif
 

--- a/oxygine/src/core/gl/oxgl.h
+++ b/oxygine/src/core/gl/oxgl.h
@@ -82,6 +82,12 @@ extern "C"
 #   define GL_GLEXT_PROTOTYPES
 #   include "GLES2/gl2ext.h"
 
+#elif __SAILFISHOS__
+#   include "GLES2/gl2.h"
+#   define GL_GLEXT_PROTOTYPES
+#   include "GLES2/gl2ext.h"
+#undef __unix__
+
 #elif __APPLE__
 #   include <TargetConditionals.h>
 #   if TARGET_OS_IPHONE

--- a/oxygine/src/core/oxygine.cpp
+++ b/oxygine/src/core/oxygine.cpp
@@ -329,7 +329,7 @@ namespace oxygine
             //flags &= ~SDL_WINDOW_FULLSCREEN;
 #endif
 
-#if TARGET_OS_IPHONE || defined(__ANDROID__)
+#if TARGET_OS_IPHONE || defined(__ANDROID__) ||  defined(__SAILFISHOS__)
             desc.w = -1;
             desc.h = -1;
 #endif
@@ -374,7 +374,7 @@ namespace oxygine
 
 #endif
 
-#if __ANDROID__ || TARGET_OS_IPHONE
+#if __ANDROID__ || TARGET_OS_IPHONE || __SAILFISHOS__
             //if (SDL_GetNumTouchDevices() > 0)
             _useTouchAPI = true;
 #endif
@@ -452,7 +452,14 @@ namespace oxygine
             log::messageln("oxygine initialized");
         }
 
-#if OXYGINE_SDL
+#if defined(__SAILFISHOS__)
+        Vector2 convertTouch(SDL_Event& ev)
+        {
+            Point size = getDisplaySize();
+            // Multiplying by screen size is not needed and breaks touch
+            return Vector2(ev.tfinger.x/* * size.x*/, ev.tfinger.y/* * size.y*/);
+        }
+#elif OXYGINE_SDL
         Vector2 convertTouch(SDL_Event& ev)
         {
             Point size = getDisplaySize();


### PR DESCRIPTION
> Sailfish OS is a general purpose Linux distribution used commonly as mobile operating system combining the Linux kernel for a particular hardware platform use, the open-source Mer core stack of middleware, a proprietary UI contributed by Jolla or an open source UI, and other third-party components.
[https://sailfishos.org/](SailfishOS webpage)

This merge request adds support to SailfishOS. For sailfishos we need cmake build type and android (opengles) instead of unix (opengl) libraries. 

The only problem left that i cannot solve myself is that sfos doesnt have -lSDL2main but instead we need to include -lGLESv2. Also take a look at oxygine/src/core/oxygine.cpp#455 multiplying by screen resolution is not needed there. If there is more proper way to fix that then we should do it.