### PR TITLE
Hotfix/compiler warnings

### DIFF
--- a/oxygine/src/oxygine/Draggable.h
+++ b/oxygine/src/oxygine/Draggable.h
@@ -41,18 +41,22 @@ namespace oxygine
         void onDrag(TouchEvent* es);
         void onMove(const Vector2& position);
 
-        Actor* _dragClient;
-        Actor* _actor;
-        timeMS _startTm;
-        bool _singleDrag;
-
         RectF _bounds;
         Vector2 _dragPos;
         Vector2 _clientPos;
+        
+        Actor* _dragClient;
+        Actor* _actor;
+        timeMS _startTm;
 
         bool _clientIsParent;
-        bool _pressed;
         bool _dragEnabled;
+        bool _pressed;
+        bool _singleDrag;
         bool _ignoreTouchUp;
+        
+
+
+
     };
 }

--- a/oxygine/src/oxygine/Event.h
+++ b/oxygine/src/oxygine/Event.h
@@ -23,15 +23,15 @@ namespace oxygine
         Event(eventType Type, bool Bubbles = false) : listenerID(0), userData(0), type(Type), phase(phase_target), bubbles(Bubbles), stopsImmediatePropagation(false), stopsPropagation(false) {}
         virtual ~Event() {}
 
+        int listenerID;
+        void* userData;
         eventType type;
         Phase phase;
         bool bubbles;
         bool stopsImmediatePropagation;
         bool stopsPropagation;
 
-        void* userData;
         spObject userDataObject;
-        int listenerID;
 
         /**The event target*/
         spEventDispatcher target;

--- a/oxygine/src/oxygine/HttpRequestTask.h
+++ b/oxygine/src/oxygine/HttpRequestTask.h
@@ -92,7 +92,6 @@ namespace oxygine
 
         std::string _url;
         std::string _fname;
-        file::handle _fhandle;
         bool _writeFileError;
         bool _cacheEnabled;
         bool _firstTimeProgressDispatched;
@@ -104,17 +103,17 @@ namespace oxygine
         std::vector<unsigned char> _response;
         std::vector<unsigned char> _postData;
 
-        responseCodeChecker _responseCodeChecker;
-
-        bool _suitableResponse;
-
-        int _responseCode;
+        bool _continueDownload;
+        
         size_t _expectedContentSize;
         size_t _receivedContentSize;
+        file::handle _fhandle;
+        bool _suitableResponse;
+        responseCodeChecker _responseCodeChecker;
+
+        int _responseCode;
 
         spObject _object;
-
-        bool _continueDownload;
 
         typedef std::vector< std::pair<std::string, std::string> >  headers;
         headers _headers;

--- a/oxygine/src/oxygine/TextStyle.h
+++ b/oxygine/src/oxygine/TextStyle.h
@@ -44,15 +44,12 @@ namespace oxygine
 
         int linesOffset;//vertical distance offset between lines
         int kerning;//horizontal distance
-        size_t options;//additional flags could be used for generating custom glyphs
         bool multiline;
+        int fontSize;
         bool breakLongWords;//works with multiline flag. breakLongWords = false doesn't allow to break too long words
         Color color;
-
-        int fontSize;
         float baselineScale;//baseline distance multiplier
-
-
+        size_t options;//additional flags could be used for generating custom glyphs
 
         TextStyle withFont(const ResFont* f) const { TextStyle st = *this; st.font = f; return st; }
 

--- a/oxygine/src/oxygine/TouchEvent.h
+++ b/oxygine/src/oxygine/TouchEvent.h
@@ -33,18 +33,18 @@ namespace oxygine
         /**position in local space for Event::target actor*/
         Vector2 position;
 
+        MouseButton mouseButton;
         float pressure;
 
-        MouseButton mouseButton;
         pointer_index index;
-
-        Vector2 wheelDirection;//actual only for WHEEL_DIR event
 
         const PointerState* getPointer() const;
 
         static bool isTouchEvent(int eventID) { return eventID > __FIRST && eventID < __LAST; }
 
         bool __clickDispatched;
+        Vector2 wheelDirection;//actual only for WHEEL_DIR event
+        
         float __localScale;
     };
 }

--- a/oxygine/src/oxygine/actor/Button.h
+++ b/oxygine/src/oxygine/actor/Button.h
@@ -31,10 +31,10 @@ namespace oxygine
         };
         virtual void updateButtonState(state s);
 
+        state _state;
         const ResAnim* _resAnim;
         int _row;
-        state _state;
-
+        
     private:
         pointer_index _btnPressed;
         pointer_index _btnOvered;

--- a/oxygine/src/oxygine/actor/DebugActor.h
+++ b/oxygine/src/oxygine/actor/DebugActor.h
@@ -48,9 +48,8 @@ namespace oxygine
         std::string _debugText;
         std::vector<int> _frameTime;
 
-
-        bool _showTouchedActor;
         bool _showTexel2PixelErrors;
+        bool _showTouchedActor;
 
         bool _dragging;
         Vector2 _local;

--- a/oxygine/src/oxygine/actor/SlidingActor.h
+++ b/oxygine/src/oxygine/actor/SlidingActor.h
@@ -57,13 +57,14 @@ namespace oxygine
         void doUpdate(const UpdateState& us)  override;
         void updateDragBounds();
 
-
         void _newEvent(Event* event);
 
         bool _sliding;
         float _rad;
         float _maxSpeed;
         timeMS _downTime;
+        
+        bool _ignoreTouchUp;
 
         Vector2 _downPos;
         Vector2 _speed;
@@ -88,8 +89,6 @@ namespace oxygine
 
         timeMS _lastIterTime;
         pointer_index _finger;
-
-        bool _ignoreTouchUp;
     };
 }
 

--- a/oxygine/src/oxygine/core/VertexDeclaration.h
+++ b/oxygine/src/oxygine/core/VertexDeclaration.h
@@ -10,9 +10,8 @@ namespace oxygine
         VertexDeclaration(): bformat(0), numElements(0), size(0) {}
 
         bvertex_format bformat;
-        int size;
-
         int numElements;
+        int size;
     };
 
     template <class T>

--- a/oxygine/src/oxygine/core/VideoDriver.h
+++ b/oxygine/src/oxygine/core/VideoDriver.h
@@ -29,7 +29,7 @@ namespace oxygine
         class Stats
         {
         public:
-            Stats() : batches(0), duration(0), start(0) { memset(elements, 0, sizeof(elements)); }
+            Stats() : batches(0), start(0), duration(0) { memset(elements, 0, sizeof(elements)); }
             int batches;
             int elements[PT_COUNT];
             timeMS start;

--- a/oxygine/src/oxygine/core/oxygine.cpp
+++ b/oxygine/src/oxygine/core/oxygine.cpp
@@ -402,8 +402,7 @@ namespace oxygine
             file::init(desc.companyName, desc.appName);
 
 #ifdef OXYGINE_SDL
- // unused variable (hotfix/compiler-warnings)
- //           int missing = initGLExtensions(SDL_GL_GetProcAddress);
+            initGLExtensions(SDL_GL_GetProcAddress);
 #endif
 
             Point size = getDisplaySize();

--- a/oxygine/src/oxygine/core/oxygine.cpp
+++ b/oxygine/src/oxygine/core/oxygine.cpp
@@ -402,7 +402,8 @@ namespace oxygine
             file::init(desc.companyName, desc.appName);
 
 #ifdef OXYGINE_SDL
-            int missing = initGLExtensions(SDL_GL_GetProcAddress);
+ // unused variable (hotfix/compiler-warnings)
+ //           int missing = initGLExtensions(SDL_GL_GetProcAddress);
 #endif
 
             Point size = getDisplaySize();

--- a/oxygine/src/oxygine/dev_tools/TreeInspector.h
+++ b/oxygine/src/oxygine/dev_tools/TreeInspector.h
@@ -42,9 +42,9 @@ namespace oxygine
         void close(Event* ev);
         void wheel(Event* ev);
 
-        Resources* _resSystem;
-
         TreeInspectorPreview* _preview;
+
+        Resources* _resSystem;
 
         spTreeInspectorPage _rootPage;
         spSlidingActor _sliding;

--- a/oxygine/src/oxygine/initActor.h
+++ b/oxygine/src/oxygine/initActor.h
@@ -76,12 +76,12 @@ namespace oxygine
 
         class animFrame
         {
-            const ResAnim* _resAnim;
             int _col;
             int _row;
+            const ResAnim* _resAnim;
+            bool _useResAnim;
             bool _managed;
             AnimationFrame _frame;
-            bool _useResAnim;
 
         public:
             animFrame(bool managed, int col, int row): _col(col), _row(row), _resAnim(0), _useResAnim(true), _managed(managed) {}

--- a/oxygine/src/oxygine/res/CreateResourceContext.h
+++ b/oxygine/src/oxygine/res/CreateResourceContext.h
@@ -66,11 +66,10 @@ namespace oxygine
         }
 
         Resources* resources;
-        XmlWalker walker;
-
         const std::string* xml_name;
         const std::string* prebuilt_folder;
         const ResourcesLoadOptions* options;
+        XmlWalker walker;
     };
 
     DECLARE_SMART(Image, spImage);


### PR DESCRIPTION
I'm using g++ on Linux and like to compile all my code with -Wall flag.
The code in the framework was generating mostly -Wreorder warnings. Hence my build output gets loaded with warnings.
In this branch, the compiler warnings are resolved.
Warnings fixed:
- mostly -Wreorder : reordered argument list or reordered class members
- some -Wunused-variable: assignment to a variable that is not used for anything -> removed variable
- 1 cast warning (unsigned int / int) -> added cast