### PR TITLE
Make windows headers lower-case to support MXE-builds

### DIFF
--- a/oxygine/src/oxygine/actor/DebugActor.cpp
+++ b/oxygine/src/oxygine/actor/DebugActor.cpp
@@ -33,7 +33,7 @@
 #elif _WIN32
 #pragma comment(lib, "psapi.lib") // Added to support GetProcessMemoryInfo()
 #include <windows.h>
-#include <Psapi.h>
+#include <psapi.h>
 #endif
 
 

--- a/oxygine/src/oxygine/core/STDFileSystem.cpp
+++ b/oxygine/src/oxygine/core/STDFileSystem.cpp
@@ -19,7 +19,7 @@
 #elif OXYGINE_SDL && !OXYGINE_FILESYSTEM_USE_STDIO
 #ifdef _WIN32
 #include <direct.h>
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include <sys/stat.h>

--- a/oxygine/src/oxygine/core/log.cpp
+++ b/oxygine/src/oxygine/core/log.cpp
@@ -12,7 +12,7 @@
 
 #else
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #define LOGD(str) fputs(str, stdout); OutputDebugStringA(str);
 #else
 #define LOGD(str) fputs(str, stdout)


### PR DESCRIPTION
MXE ( https://mxe.cc/ ) allows to build windows-binaries on linux, however windows-headers are in lower cases. File-systems on Unices are case-sensitive, so, MXE (`i686-w64-mingw32.static.posix-g++`)  cannot find them. 

This should be safe for Windows change, as FS on Windows is case-insensitive. 