### PR TITLE
Disable inclusion pthread-heaaders via #ifdef

### DIFF
--- a/oxygine/src/oxygine/core/Mutex.cpp
+++ b/oxygine/src/oxygine/core/Mutex.cpp
@@ -6,6 +6,7 @@ namespace oxygine
 {
     Mutex::Mutex(bool recursive)
     {
+#ifndef OX_NO_MT
         if (recursive)
         {
             pthread_mutexattr_t   mta;
@@ -18,20 +19,27 @@ namespace oxygine
         {
             pthread_mutex_init(&_handle, 0);
         }
+#endif
     }
 
     Mutex::~Mutex()
     {
+#ifndef OX_NO_MT
         pthread_mutex_destroy(&_handle);
+#endif
     }
 
     void Mutex::lock()
     {
+#ifndef OX_NO_MT
         pthread_mutex_lock(&_handle);
+#endif
     }
 
     void Mutex::unlock()
     {
+#ifndef OX_NO_MT
         pthread_mutex_unlock(&_handle);
+#endif
     }
 }

--- a/oxygine/src/oxygine/core/ThreadDispatcher.cpp
+++ b/oxygine/src/oxygine/core/ThreadDispatcher.cpp
@@ -19,15 +19,19 @@ namespace oxygine
 #endif
 
 
+#ifndef OX_NO_MT
     MutexPthreadLock::MutexPthreadLock(pthread_mutex_t& m, bool lock) : _mutex(m), _locked(lock)
     {
         if (_locked)
             pthread_mutex_lock(&_mutex);
     }
+#endif
 
     MutexPthreadLock::~MutexPthreadLock()
     {
+#ifndef OX_NO_MT
         pthread_mutex_unlock(&_mutex);
+#endif
     }
 
     ThreadDispatcher::ThreadDispatcher(): _id(0), _result(0)
@@ -192,8 +196,8 @@ namespace oxygine
 #ifndef OX_NO_MT
             //pthread_cond_signal(&_cond);
             pthread_cond_broadcast(&_cond);
-#endif
             pthread_cond_wait(&_cond, &_mutex);
+#endif
         }
     }
 
@@ -206,8 +210,8 @@ namespace oxygine
             LOGDN("ThreadMessages::waiting reply... _replyingTo=%d  myid=%d", _replyingTo, id);
 #ifndef OX_NO_MT
             pthread_cond_signal(&_cond);
-#endif
             pthread_cond_wait(&_cond, &_mutex);
+#endif
         }
         while (_replyingTo != id);
 
@@ -364,11 +368,15 @@ namespace oxygine
 
     std::vector<ThreadDispatcher::message>& ThreadDispatcher::lockMessages()
     {
+#ifndef OX_NO_MT
         pthread_mutex_lock(&_mutex);
+#endif
         return _events;
     }
     void ThreadDispatcher::unlockMessages()
     {
+#ifndef OX_NO_MT
         pthread_mutex_unlock(&_mutex);
+#endif
     }
 }

--- a/oxygine/src/oxygine/core/ThreadDispatcher.h
+++ b/oxygine/src/oxygine/core/ThreadDispatcher.h
@@ -15,11 +15,15 @@ namespace oxygine
     class MutexPthreadLock
     {
     public:
+#ifndef OX_NO_MT
         MutexPthreadLock(pthread_mutex_t& m, bool lock = true);
+#endif
         ~MutexPthreadLock();
 
     protected:
+#ifndef OX_NO_MT
         pthread_mutex_t& _mutex;
+#endif
         bool _locked;
     };
     /*


### PR DESCRIPTION
If `phread` is not available and not used, the phread-related structures might be not available at compile-time (e.g. for `mxe` the `i686-w64-mingw32.static` version does not provides pthread.h, while `i686-w64-mingw32.static.posix` does).

This PR uses `OX_NO_MT` macros to guard phread structures usage.