### PR TITLE
[Actor] Anchor modifies origin

### DIFF
--- a/oxygine/src/oxygine/actor/Actor.cpp
+++ b/oxygine/src/oxygine/actor/Actor.cpp
@@ -793,20 +793,21 @@ namespace oxygine
                      -s * _scale.y, c * _scale.y,
                      _pos.x, _pos.y);
         }
+        if (!(_flags&flag_anchorAffectsOrigin)) {
+           Vector2 offset;
+           if (_flags & flag_anchorInPixels)
+           {
+               offset.x = -_anchor.x;
+               offset.y = -_anchor.y;
+           }
+           else
+           {
+               offset.x = -float(_size.x * _anchor.x);
+               offset.y = -float(_size.y * _anchor.y);//todo, what to do? (per pixel quality)
+           }
 
-        Vector2 offset;
-        if (_flags & flag_anchorInPixels)
-        {
-            offset.x = -_anchor.x;
-            offset.y = -_anchor.y;
+           tr.translate(offset);
         }
-        else
-        {
-            offset.x = -float(_size.x * _anchor.x);
-            offset.y = -float(_size.y * _anchor.y);//todo, what to do? (per pixel quality)
-        }
-
-        tr.translate(offset);
 
 
         _transform = tr;
@@ -1155,8 +1156,6 @@ namespace oxygine
         }
         else
             Transform::multiply(rs.transform, tr, parentRS.transform);
-
-
         if (_flags & flag_cull)
         {
             RectF ss_rect = getActorTransformedDestRect(this, rs.transform);
@@ -1169,18 +1168,7 @@ namespace oxygine
         return true;
     }
 
-    void Actor::completeRender(RenderState& rs)
-    {
-      if (getAnchorAffectsOrigin() && Vector2() != getAnchor()) {
-         Vector2 offset;
-         if (_flags&flag_anchorInPixels)
-            offset = getAnchor();
-         else {
-            offset.x = getAnchorX()*getWidth();
-            offset.y = getAnchorY()*getHeight();
-         }
-         rs.transform.translate(offset);
-      }
+    void Actor::completeRender(const RenderState& rs) {
     }
 
     bool Actor::internalRender(RenderState& rs, const RenderState& parentRS)
@@ -1225,7 +1213,8 @@ namespace oxygine
 
     RectF Actor::getDestRect() const
     {
-        return RectF(Vector2(0, 0), getSize());
+        Vector2 origin;
+        return RectF(alterOrigin(origin), getSize());
     }
 
     spTween Actor::_addTween(spTween tween, bool rel)
@@ -1676,5 +1665,18 @@ namespace oxygine
         }
 
         return false;
+    }
+    Vector2 Actor::alterOrigin(const Vector2& pos) const {
+       Vector2 delta;
+       if (_flags&flag_anchorAffectsOrigin && delta!= getAnchor()) {
+          if (_flags&flag_anchorInPixels) {
+             delta = getAnchor()*-1;
+          } else {
+             delta.x = -getAnchorX()*getSize().x;
+             delta.y = -getAnchorY()*getSize().y;
+          }
+          return pos+delta;
+       }
+       return pos;
     }
 }

--- a/oxygine/src/oxygine/actor/Actor.cpp
+++ b/oxygine/src/oxygine/actor/Actor.cpp
@@ -20,6 +20,7 @@
 namespace oxygine
 {
     CREATE_COPYCLONE_NEW(Actor);
+    unsigned int Actor::DEFAULT_FLAGS = flag_visible | flag_touchEnabled | flag_touchChildrenEnabled | flag_fastTransform;
 
     std::string div(const std::string& val, const Color& color)
     {
@@ -33,7 +34,7 @@ namespace oxygine
         _zOrder(0),
         _scale(1, 1),
         _rotation(0),
-        _flags(flag_visible | flag_touchEnabled | flag_touchChildrenEnabled | flag_fastTransform),
+        _flags(Actor::DEFAULT_FLAGS),
         _parent(0),
         _alpha(255),
         _stage(0),
@@ -1168,9 +1169,18 @@ namespace oxygine
         return true;
     }
 
-    void Actor::completeRender(const RenderState& rs)
+    void Actor::completeRender(RenderState& rs)
     {
-
+      if (getAnchorAffectsOrigin() && Vector2() != getAnchor()) {
+         Vector2 offset;
+         if (_flags&flag_anchorInPixels)
+            offset = getAnchor();
+         else {
+            offset.x = getAnchorX()*getWidth();
+            offset.y = getAnchorY()*getHeight();
+         }
+         rs.transform.translate(offset);
+      }
     }
 
     bool Actor::internalRender(RenderState& rs, const RenderState& parentRS)

--- a/oxygine/src/oxygine/actor/Actor.h
+++ b/oxygine/src/oxygine/actor/Actor.h
@@ -264,6 +264,7 @@ namespace oxygine
         virtual Vector2 parent2local(const Vector2& pos) const;
         //converts local position to parent space
         virtual Vector2 local2parent(const Vector2& pos = Vector2(0, 0)) const;
+        virtual Vector2 alterOrigin(const Vector2& pos) const;
 
         //converts local position to Stage
         Vector2 local2stage(const Vector2& pos = Vector2(0, 0), Actor* stage = 0) const;
@@ -337,7 +338,7 @@ namespace oxygine
         spTween _addTween(spTween tween, bool rel);
 
         bool prepareRender(RenderState& rs, const RenderState& parentRS);
-        void completeRender(RenderState& rs);
+        void completeRender(const RenderState& rs);
 
 
         void markTranformDirty();

--- a/oxygine/src/oxygine/actor/Actor.h
+++ b/oxygine/src/oxygine/actor/Actor.h
@@ -42,7 +42,8 @@ namespace oxygine
     class Actor: public EventDispatcher, public intrusive_list_item<spActor>, public Serializable
     {
         typedef intrusive_list_item<spActor> intr_list;
-
+    public:
+        static unsigned int DEFAULT_FLAGS;
     public:
         Actor(const Actor& src, cloneOptions opt = 0);
         virtual Actor* clone(cloneOptions opt = 0) const;
@@ -95,6 +96,7 @@ namespace oxygine
         float               getRotationDegrees() const {return _rotation / MATH_PI * 180.0f;}
         int                 getPriority() const {return _zOrder;}
         bool                getVisible() const {return (_flags & flag_visible) != 0;}
+        bool                getAnchorAffectsOrigin() const {return (_flags & flag_anchorAffectsOrigin) != 0;}
         Actor*              getParent() {return _parent;}
         const Actor*        getParent() const {return _parent;}
         const Vector2&      getSize() const {return _size;}
@@ -173,6 +175,7 @@ namespace oxygine
 
         /**Show/Hide actor and children. Invisible Actor doesn't receive Touch events.*/
         void setVisible(bool vis) {_flags &= ~flag_visible; if (vis) _flags |= flag_visible;}
+        void setAnchorAffectsOrigin(bool aff) {_flags &= ~flag_anchorAffectsOrigin; if (aff) _flags |= flag_anchorAffectsOrigin;}
         /**Enable/Disable culling this actor outside of clip area (use it in pair with ClipRectActor)*/
         void setCull(bool enable) {_flags &= ~flag_cull; if (enable) _flags |= flag_cull;}
         /**Sets transparency. if alpha is 0 actor and children are completely invisible. Invisible Actor doesn't receive Touch events.*/
@@ -334,7 +337,7 @@ namespace oxygine
         spTween _addTween(spTween tween, bool rel);
 
         bool prepareRender(RenderState& rs, const RenderState& parentRS);
-        void completeRender(const RenderState& rs);
+        void completeRender(RenderState& rs);
 
 
         void markTranformDirty();
@@ -347,24 +350,6 @@ namespace oxygine
 
         mutable Transform _transform;
         mutable Transform _transformInvert;
-
-
-        enum flags
-        {
-            flag_anchorInPixels         = 1,
-            flag_visible                = 1 << 1,
-            flag_touchEnabled           = 1 << 2,
-            flag_transformDirty         = 1 << 3,
-            flag_transformInvertDirty   = 1 << 4,
-            flag_touchChildrenEnabled   = 1 << 5,
-            flag_cull                   = 1 << 6,
-            flag_fastTransform          = 1 << 7,
-            flag_boundsNoChildren       = 1 << 8,
-            flag_actorHasBounds         = 1 << 9,
-            flag_clickableWithZeroAlpha = 1 << 10,
-            flag_reserved               = 1 << 11,
-            flag_last                   = flag_reserved
-        };
 
         mutable unsigned int _flags;
         unsigned char   _alpha;
@@ -388,8 +373,24 @@ namespace oxygine
             };
             int32_t _pressedOvered;
         };
-
-
+   public:
+        enum flags
+        {
+            flag_anchorInPixels         = 1,
+            flag_visible                = 1 << 1,
+            flag_touchEnabled           = 1 << 2,
+            flag_transformDirty         = 1 << 3,
+            flag_transformInvertDirty   = 1 << 4,
+            flag_touchChildrenEnabled   = 1 << 5,
+            flag_cull                   = 1 << 6,
+            flag_fastTransform          = 1 << 7,
+            flag_boundsNoChildren       = 1 << 8,
+            flag_actorHasBounds         = 1 << 9,
+            flag_clickableWithZeroAlpha = 1 << 10,
+            flag_reserved               = 1 << 11,
+            flag_anchorAffectsOrigin    = 1 << 12,
+            flag_last                   = flag_anchorAffectsOrigin
+        };
     private:
 
         Vector2 _pos;

--- a/oxygine/src/oxygine/actor/DebugActor.cpp
+++ b/oxygine/src/oxygine/actor/DebugActor.cpp
@@ -397,6 +397,12 @@ namespace oxygine
                 pos.y -= realSize.y;
                 break;
         }
+        Vector2 o = getStage()->getAnchor();
+        if (getStage()->getAnchorAffectsOrigin() && o != Vector2()) {
+           Vector2 sz = getStage()->getSize();
+           pos.x -= sz.x*o.x;
+           pos.y -= sz.y*o.y;
+        }
 
         setPosition(pos);
         setScale(1.0f / getStage()->getScaleX());

--- a/oxygine/src/oxygine/actor/Sprite.cpp
+++ b/oxygine/src/oxygine/actor/Sprite.cpp
@@ -288,6 +288,9 @@ namespace oxygine
         RectF r = _frame.getDestRect();
         r.pos = r.pos.mult(_localScale);
         r.size = r.size.mult(_localScale);
+
+        r.pos = alterOrigin(r.pos);
+
         return r;
     }
 


### PR DESCRIPTION
This changes the inner origin of an actor to be in line with its anchor if it has the flag_AnchorAffectsOrigin enabled (and repositions the DebugActor acordingly)

As a nice feature I made an Actor::DEFAULT_FLAGS to set it for everithing made afterwards