### PR TITLE
Add Texture format to post processing options

### DIFF
--- a/oxygine/src/oxygine/PostProcess.cpp
+++ b/oxygine/src/oxygine/PostProcess.cpp
@@ -358,7 +358,7 @@ namespace oxygine
         driver->setTexture(0, 0);
     }
 
-    PostProcess::PostProcess(const PostProcessOptions& opt) : _options(opt), _format(TF_R4G4B4A4), _extend(2, 2)
+    PostProcess::PostProcess(const PostProcessOptions& opt) : _options(opt), _format(opt._format), _extend(2, 2)
     {
     }
 

--- a/oxygine/src/oxygine/PostProcess.h
+++ b/oxygine/src/oxygine/PostProcess.h
@@ -19,18 +19,20 @@ namespace oxygine
             flag_fixedBounds = 1 << 3,
         };
 
-        PostProcessOptions(int flags = 0) : _flags(flags), _downscale(1), _clearColor(0, 0, 0, 0) {}
+        PostProcessOptions(int flags = 0) : _flags(flags), _downscale(1), _clearColor(0, 0, 0, 0), _format(TF_R4G4B4A4) {}
         PostProcessOptions& fullscreen(bool enable = true) { _flags = enable ? (_flags | flag_fullscreen) : (_flags  & (~flag_fullscreen)); return *this; }
         PostProcessOptions& singleRender(bool enable = true) { _flags = enable ? (_flags | flag_singleR2T) : (_flags  & (~flag_singleR2T)); return *this; }
         //loops -(2, 3, 4, ...),  final size: 2^loops
         PostProcessOptions& downscale(int loops = 2) { _downscale = loops; return *this; }
         PostProcessOptions& clear(const Color& c) { _clearColor = c; return *this; }
         PostProcessOptions& fixedBounds(const RectF& b) { _fixedBounds = b; _flags |= flag_fixedBounds; return *this; }
+        PostProcessOptions& format(TextureFormat tf) { _format = tf; return *this; }
 
         int _flags;
         int _downscale;
         RectF _fixedBounds;
         Color _clearColor;
+        TextureFormat _format;
     };
 
 


### PR DESCRIPTION
Post processing uses TF_R4G4B4A4 for its texture format. For most purposes it's ok, but if you are showing a TF_R8G8B8A8 texture as background and use TweenAlphaFade to go to the other, it shows artifacts.

To avoid this I added TextureFormat to the post processing options to let anyone choose which texture format to use for postprocessing