### PR TITLE
Fixes on InputText

### DIFF
--- a/oxygine/src/oxygine/InputText.cpp
+++ b/oxygine/src/oxygine/InputText.cpp
@@ -11,10 +11,12 @@ namespace oxygine
 {
     InputText* InputText::_active = 0;
 
-    InputText::InputText(): _maxLength(0)
+    InputText::InputText(int cursorSpeed): _maxLength(0)
     {
         _cursor = new ColorRectSprite;
-        _cursor->addTween(Actor::TweenAlpha(0), 400, -1, true);
+        if (cursorSpeed > 0) {
+           _cursor->addTween(Actor::TweenAlpha(0), cursorSpeed, -1, true);
+        }
         _cursor->setVisible(false);
     }
 
@@ -59,7 +61,7 @@ namespace oxygine
 
         SDL_StartTextInput();
 
-        _txt = "";
+        _txt = ta->getText();
         updateText();
     }
 

--- a/oxygine/src/oxygine/InputText.h
+++ b/oxygine/src/oxygine/InputText.h
@@ -15,7 +15,7 @@ namespace oxygine
         enum {EVENT_TEXT_CHANGED = sysEventID('I', 'T', 'C') };
         enum {EVENT_COMPLETE = Event::COMPLETE};
 
-        InputText();
+        InputText(int cursorSpeed = 400);
         ~InputText();
 
         /**Shows virtual keyboard(if supported on platform) and sends pressed chars to TextField*/


### PR DESCRIPTION
InputText clears the text on focus, as it's a decorator, this shouldn't be the case.

I also parametrized the blinking speed of the cursor, leaving by default what it had