### PR TITLE
[Feature] Half-Pixel correction on prebuilt atlasses

### DIFF
--- a/oxygine/src/oxygine/res/ResAtlasPrebuilt.cpp
+++ b/oxygine/src/oxygine/res/ResAtlasPrebuilt.cpp
@@ -159,7 +159,11 @@ namespace oxygine
                         float iw = 1.0f / texture->getWidth();
                         float ih = 1.0f / texture->getHeight();
 
-                        RectF srcRect(x * iw, y * ih, bbox_w * iw, bbox_h * ih);
+                        RectF srcRect(
+                           (x+0.5) * iw, 
+                           (y+0.5) * ih, 
+                           (bbox_w-1) * iw, 
+                           (bbox_h-1) * ih);
 
                         float fs = frame_scale;
                         RectF destRect(


### PR DESCRIPTION
Lets have a small texture (lets say under 10 px wide) 
put it in a big atlas (1024x1024) somewhere in the middle
create a sprite with said texture and set its width to something big, maybe 500px
neigbour pixels of the atlas bleed into it
that's because the UV coords refer to the left border of the most left pixel and to the right border of the most right pixel of the texture
this pull request adresses this by imposing a halfpixel correction on AnimationFrame Generation time making the UVs point to the middle of those pixels
